### PR TITLE
Upstream merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "async": "2.1.4",
     "globby": "6.1.0",
     "htmlparser2": "3.9.2",
-    "lodash": "4.17.2",
+    "lodash": "4.17.19",
     "pug": "2.0.0-beta6",
     "svgo": "0.7.1"
   },

--- a/src/svgstore.js
+++ b/src/svgstore.js
@@ -76,13 +76,14 @@ class WebpackSvgStore {
 
   apply(compiler) {
     // AST parser
-    compiler.plugin('compilation', (compilation, data) => {
-      
+    compiler.hooks.compilation.tap({name: 'WebpackSvgStore'}, (compilation) => {
       compilation.dependencyFactories.set(ConstDependency, new NullFactory());
       compilation.dependencyTemplates.set(ConstDependency, new ConstDependency.Template());
-      
-      data.normalModuleFactory.plugin('parser', (parser, options) => {
-        parser.plugin('statement', (expr) => {
+    });
+
+    compiler.hooks.normalModuleFactory.tap({name: 'WebpackSvgStore'}, factory => {
+      factory.hooks.parser.for('javascript/auto').tap({name: 'WebpackSvgStore'}, (parser, options) => {
+        parser.hooks.statement.tap({name: 'WebpackSvgStore'}, (expr) => {
           if (!expr.declarations || !expr.declarations.length) return;
           const thisExpr = expr.declarations[0];
           if ([
@@ -91,36 +92,35 @@ class WebpackSvgStore {
             '__svgstore__',
             '__svgsprite__',
             '__webpack_svgstore__'
-          ].indexOf(thisExpr.id.name) > -1) {
+          ].indexOf(thisExpr.id.name) !== -1) {
             return this.createTaskContext(thisExpr, parser);
           }
         });
       });
     });
 
-
     // save file to fs
-    compiler.plugin('emit', (compilation, callback) => {
+    compiler.hooks.emit.tap({name: 'WebpackSvgStore'}, (compilation, callback) => {
       async.forEach(Object.keys(this.tasks),
         (key, outerCallback) => {
           async.forEach(this.tasks[key],
-            (task, callback) => {
-              // add sprite to assets
-              compilation.assets[task.fileName] = {
-                size: function () {
-                  return Buffer.byteLength(task.fileContent, 'utf8');
-                },
-                source: function () {
-                  return new Buffer(task.fileContent);
-                }
-              };
-              // done
-              callback();
-            }, outerCallback);
+          (task, callback) => {
+            // add sprite to assets
+            compilation.assets[task.fileName] = {
+              size: function () {
+                return Buffer.byteLength(task.fileContent, 'utf8');
+              },
+              source: function () {
+                return new Buffer(task.fileContent);
+              }
+            };
+            // done
+            callback();
+          }, outerCallback);
         }, callback);
     });
 
-    compiler.plugin('done', () => {
+    compiler.hooks.done.tap({name: 'WebpackSvgStore'}, () => {
       this.tasks = {};
     });
   }

--- a/src/svgstore.js
+++ b/src/svgstore.js
@@ -76,53 +76,103 @@ class WebpackSvgStore {
 
   apply(compiler) {
     // AST parser
-    compiler.hooks.compilation.tap({name: 'WebpackSvgStore'}, (compilation) => {
-      compilation.dependencyFactories.set(ConstDependency, new NullFactory());
-      compilation.dependencyTemplates.set(ConstDependency, new ConstDependency.Template());
-    });
+    if (compiler.hooks) { //webpack ^4.0.0
+      compiler.hooks.compilation.tap({name: 'WebpackSvgStore'}, (compilation) => {
+        compilation.dependencyFactories.set(ConstDependency, new NullFactory());
+        compilation.dependencyTemplates.set(ConstDependency, new ConstDependency.Template());
+      });
 
-    compiler.hooks.normalModuleFactory.tap({name: 'WebpackSvgStore'}, factory => {
-      factory.hooks.parser.for('javascript/auto').tap({name: 'WebpackSvgStore'}, (parser, options) => {
-        parser.hooks.statement.tap({name: 'WebpackSvgStore'}, (expr) => {
-          if (!expr.declarations || !expr.declarations.length) return;
-          const thisExpr = expr.declarations[0];
-          if ([
-            '__svg__',
-            '__sprite__',
-            '__svgstore__',
-            '__svgsprite__',
-            '__webpack_svgstore__'
-          ].indexOf(thisExpr.id.name) !== -1) {
-            return this.createTaskContext(thisExpr, parser);
-          }
+      compiler.hooks.normalModuleFactory.tap({name: 'WebpackSvgStore'}, factory => {
+        factory.hooks.parser.for('javascript/auto').tap({name: 'WebpackSvgStore'}, (parser, options) => {
+          parser.hooks.statement.tap({name: 'WebpackSvgStore'}, (expr) => {
+            if (!expr.declarations || !expr.declarations.length) return;
+            const thisExpr = expr.declarations[0];
+            if ([
+              '__svg__',
+              '__sprite__',
+              '__svgstore__',
+              '__svgsprite__',
+              '__webpack_svgstore__'
+            ].indexOf(thisExpr.id.name) !== -1) {
+              return this.createTaskContext(thisExpr, parser);
+            }
+          });
         });
       });
-    });
 
-    // save file to fs
-    compiler.hooks.emit.tap({name: 'WebpackSvgStore'}, (compilation, callback) => {
-      async.forEach(Object.keys(this.tasks),
-        (key, outerCallback) => {
-          async.forEach(this.tasks[key],
-          (task, callback) => {
-            // add sprite to assets
-            compilation.assets[task.fileName] = {
-              size: function () {
-                return Buffer.byteLength(task.fileContent, 'utf8');
-              },
-              source: function () {
-                return new Buffer(task.fileContent);
-              }
-            };
-            // done
-            callback();
-          }, outerCallback);
-        }, callback);
-    });
+      // save file to fs
+      compiler.hooks.emit.tap({name: 'WebpackSvgStore'}, (compilation, callback) => {
+        async.forEach(Object.keys(this.tasks),
+          (key, outerCallback) => {
+            async.forEach(this.tasks[key],
+            (task, callback) => {
+              // add sprite to assets;
+              compilation.assets[task.fileName] = {
+                size: function () {
+                  return Buffer.byteLength(task.fileContent, 'utf8');
+                },
+                source: function () {
+                  return new Buffer(task.fileContent);
+                }
+              };
+              // done
+              callback();
+            }, outerCallback);
+          }, callback);
+      });
 
-    compiler.hooks.done.tap({name: 'WebpackSvgStore'}, () => {
-      this.tasks = {};
-    });
+      compiler.hooks.done.tap({name: 'WebpackSvgStore'}, () => {
+        this.tasks = {};
+      });
+    } else {
+      // AST parser
+      compiler.plugin('compilation', (compilation, data) => {
+        
+        compilation.dependencyFactories.set(ConstDependency, new NullFactory());
+        compilation.dependencyTemplates.set(ConstDependency, new ConstDependency.Template());
+        
+        data.normalModuleFactory.plugin('parser', (parser, options) => {
+          parser.plugin('statement', (expr) => {
+            if (!expr.declarations || !expr.declarations.length) return;
+            const thisExpr = expr.declarations[0];
+            if ([
+              '__svg__',
+              '__sprite__',
+              '__svgstore__',
+              '__svgsprite__',
+              '__webpack_svgstore__'
+            ].indexOf(thisExpr.id.name) > -1) {
+              return this.createTaskContext(thisExpr, parser);
+            }
+          });
+        });
+      });
+
+      // save file to fs
+      compiler.plugin('emit', (compilation, callback) => {
+        async.forEach(Object.keys(this.tasks),
+          (key, outerCallback) => {
+            async.forEach(this.tasks[key],
+              (task, callback) => {
+                // add sprite to assets
+                compilation.assets[task.fileName] = {
+                  size: function () {
+                    return Buffer.byteLength(task.fileContent, 'utf8');
+                  },
+                  source: function () {
+                    return new Buffer(task.fileContent);
+                  }
+                };
+                // done
+                callback();
+              }, outerCallback);
+          }, callback);
+      });
+
+      compiler.plugin('done', () => {
+        this.tasks = {};
+      });
+    }
   }
 }
 


### PR DESCRIPTION
Merges in some commits from upstream:
* Updates lodash dependency
* Updates Tapable.plugin for new hook methods, which will remove the following warning when running dev server in UI:
```
(node:54843) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
```

Tests are still failing, but they were failing before this with the version of svgo that we are using anyway